### PR TITLE
Split image descriptions

### DIFF
--- a/cmd/k8s-pipeliner/main.go
+++ b/cmd/k8s-pipeliner/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// Version defines the current version of k8s-pipeliner
-	Version = "0.0.7"
+	Version = "0.0.8"
 )
 
 func main() {

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -101,7 +101,11 @@ func (b *Builder) buildRunJobStage(index int, s config.Stage) (*types.RunJobStag
 		DNSPolicy:         "ClusterFirst", // hack for now
 	}
 
-	mg, err := ContainersFromManifest(s.RunJob.ManifestFile)
+	parser := &ManifestParser{
+		config: b.pipeline,
+	}
+
+	mg, err := parser.ContainersFromScaffold(s.RunJob)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +134,12 @@ func (b *Builder) buildDeployStage(index int, s config.Stage) (*types.DeployStag
 		StageMetadata: buildStageMetadata(s, "deploy", index, b.isLinear),
 	}
 
+	parser := &ManifestParser{
+		config: b.pipeline,
+	}
+
 	for _, group := range s.Deploy.Groups {
-		mg, err := ContainersFromManifest(group.ManifestFile)
+		mg, err := parser.ContainersFromScaffold(group)
 		if err != nil {
 			return nil, err
 		}

--- a/pipeline/builder/testdata/deployment.full.yml
+++ b/pipeline/builder/testdata/deployment.full.yml
@@ -13,7 +13,8 @@ spec:
         app: example
     spec:
       containers:
-      - command:
+      - name: test-container
+        command:
         - echo
         - hello
         env:

--- a/pipeline/config/config_test.go
+++ b/pipeline/config/config_test.go
@@ -29,4 +29,6 @@ func TestNewConfig(t *testing.T) {
 
 	require.Len(t, cfg.Stages[1].Deploy.Groups, 1, "no groups on deploy stage")
 	assert.Equal(t, cfg.Stages[1].Deploy.Groups[0].ManifestFile, "manifests/deploy/connect.yml")
+
+	require.Len(t, cfg.ImageDescriptions, 1, "image descriptions was empty")
 }

--- a/pipeline/config/testdata/pipeline.full.yaml
+++ b/pipeline/config/testdata/pipeline.full.yaml
@@ -5,6 +5,14 @@ triggers:
     job: "Connect/job/master"
     master: "namely-jenkins"
     propertyFile: "build.properties"
+imageDescriptions:
+  - name: testImageRef
+    account: account
+    image_id: image_id
+    registry: registry
+    repository: repository
+    tag: tag
+    organization: organization
 stages:
 - account: int-k8s
   name: "Migrate INT"

--- a/test-deployment.yml
+++ b/test-deployment.yml
@@ -3,13 +3,6 @@ kind: Deployment
 metadata:
   name: example
   namespace: production
-  annotations:
-    namely.com/spinnaker-image-description-account: "your-registry"
-    namely.com/spinnaker-image-description-imageid: "${ trigger.properties['docker_image'] }"
-    namely.com/spinnaker-image-description-registry: "your.registry.land"
-    namely.com/spinnaker-image-description-repository: "org/example"
-    namely.com/spinnaker-image-description-tag: "${ trigger.properties['docker_tag'] }"
-    namely.com/spinnaker-load-balancers: "example"
 spec:
   template:
     metadata:
@@ -24,7 +17,8 @@ spec:
               - key: "hello"
                 path: "/my/file/path"
       containers:
-      - command:
+      - name: example
+        command:
         - bundle
         - exec
         - unicorn
@@ -45,7 +39,6 @@ spec:
         # this image doesn't really matter, its going to be replaced, but its not to show intent
         image: your.registry.land/org/example:latest
         imagePullPolicy: IfNotPresent
-        name: example
         ports:
         - containerPort: 80
           name: http

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -5,12 +5,23 @@ triggers:                # list of triggers (currently only jenkins is supported
     job: "Example/job/master"
     master: "jenkins"
     propertyFile: "build.properties"
+imageDescriptions:
+  - name: main-image
+    account: "namely-registry"
+    image_id: "${ trigger.properties['docker_image'] }"
+    registry: "registry.namely.land"
+    repository: "namely/example-all-day"
+    tag: "${ trigger.properties['docker_tag'] }"
+    organization: "namely"
 stages:
 - account: int-k8s
   name: "Migrate INT"
   refId: "1"
   runJob:
     manifestFile: test-deployment.yml
+    imageDescription:
+      name: main-image
+      containerName: example
     container: # override default command defined in the manifest
       command:
         - bundle
@@ -43,6 +54,9 @@ stages:
         strategy: redblack
         targetSize: 2 # this is the total amount of replicas for the deployment
         containerOverrides: {}
+        imageDescription:
+          name: main-image
+          containerName: example
         loadBalancers:
           - "test"
 - account: int-k8s


### PR DESCRIPTION
This corrects a design mistake assuming that deployments would only ever have one container inside of them, preventing you from injecting in different images for the other containers defined in the pod spec. Instead, you now define a imageDescription in your pipeline.yml and reference that throughout your stages to inject in the container image spec.