### PR TITLE
Making Configmaps/Secrets Optional

### DIFF
--- a/pipeline/builder/kubernetes.go
+++ b/pipeline/builder/kubernetes.go
@@ -181,19 +181,28 @@ func (mp *ManifestParser) deploymentContainers(dep *appsv1.Deployment, scaffold 
 
 			if vf := env.ValueFrom; vf != nil {
 				if vf.ConfigMapKeyRef != nil {
+					if vf.ConfigMapKeyRef.Optional == nil {
+						vf.ConfigMapKeyRef.Optional = newFalse()
+					}
+
 					e.EnvSource = &types.EnvSource{
 						ConfigMapSource: &types.ConfigMapSource{
 							ConfigMapName: vf.ConfigMapKeyRef.Name,
 							Key:           vf.ConfigMapKeyRef.Key,
+							Optional:      *vf.ConfigMapKeyRef.Optional,
 						},
 					}
 				}
 
 				if vf.SecretKeyRef != nil {
+					if vf.SecretKeyRef.Optional == nil {
+						vf.SecretKeyRef.Optional = newFalse()
+					}
 					e.EnvSource = &types.EnvSource{
 						SecretSource: &types.SecretSource{
 							Key:        vf.SecretKeyRef.Key,
 							SecretName: vf.SecretKeyRef.Name,
+							Optional:   *vf.SecretKeyRef.Optional,
 						},
 					}
 				}
@@ -279,4 +288,9 @@ func spinnakerProbeHandler(probe *corev1.Probe) *types.Probe {
 		TimeoutSeconds:      probe.TimeoutSeconds,
 		Handler:             h,
 	}
+}
+
+func newFalse() *bool {
+	b := false
+	return &b
 }

--- a/pipeline/builder/testdata/deployment.optional.yml
+++ b/pipeline/builder/testdata/deployment.optional.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: example
+  namespace: fake-namespace
+  annotations:
+    fake-annotation-1: "Hello"
+    fake-annotation-2: "World"
+spec:
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+      - command:
+        - echo
+        - hello
+        env:
+        - name: PEPPER
+          valueFrom:
+            secretKeyRef:
+              name: secrets
+              key: pepper
+              optional: false
+        - name: SALT
+          valueFrom:
+            configMapKeyRef:
+              key: configs
+              name: salt
+              optional: true
+        - name: EXISTENCE
+          valueFrom:
+            configMapKeyRef:
+              key: configs
+              name: mundane
+        image: bird.word/latest

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -197,12 +197,14 @@ type EnvSource struct {
 type SecretSource struct {
 	SecretName string `json:"secretName"`
 	Key        string `json:"key"`
+	Optional   bool   `json:"optional"`
 }
 
 // ConfigMapSource is a env var from a config map in k8s
 type ConfigMapSource struct {
 	ConfigMapName string `json:"configMapName"`
 	Key           string `json:"key"`
+	Optional      bool   `json:"optional"`
 }
 
 // ImageDescription is used to tell spinnaker which image to use for a stage

--- a/test-deployment.yml
+++ b/test-deployment.yml
@@ -43,6 +43,12 @@ spec:
             configMapKeyRef:
               key: ADMIN_PASSWORD
               name: super-secret-password
+              optional: true
+        - name: ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: ADMIN_USERNAME
+              name: super-secret-username
         # this image doesn't really matter, its going to be replaced, but its not to show intent
         image: your.registry.land/org/example:latest
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
I found this undocumented portion of Spinnaker showing that config maps and secrets are optional by default. This makes troubleshooting difficult on new deployments if you don't have it set to false.

https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy#L241-L255

https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy#L690-L693

Also, I didn't know what's the proper go-ism for creating a pointer to a bool. LMK if this setter is okay.

