### PR TITLE
update readme with linear flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ k8s-pipeliner create pipeline.yml | jq .
 To copy the result to your clipboard and you're on a Mac, you can do:
 
 ```
-$ k8s-pipeliner create pipeline.yml | pbcopy
+$ k8s-pipeliner create --linear pipeline.yml | pbcopy
 ```
 
 ### Adding the Pipeline JSON


### PR DESCRIPTION
for some reason spinnaker throws a refid error if the pipeline json is not created with the linear flag


![screen shot 2018-03-05 at 6 41 01 pm](https://user-images.githubusercontent.com/5009828/37040073-faad4824-2126-11e8-8b90-862cd6de4d71.png)
