### PR TITLE
Add Name and Application for Spinnaker pipeline types

### DIFF
--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -7,7 +7,9 @@ import (
 // SpinnakerPipeline defines the fields for the top leve object of a spinnaker
 // pipeline. Mostly used for constructing JSON
 type SpinnakerPipeline struct {
-	ID string `json:"id,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Application string `json:"application,omitempty"`
 
 	Triggers      []Trigger      `json:"triggers"`
 	Stages        []Stage        `json:"stages"`


### PR DESCRIPTION
Adds the application name to the `SpinnakerPipeline` type so we can post this to the Spinnaker API to update pipelines automatically.