### PR TITLE
Default RequisiteStageRefIds to empty slice

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -79,6 +79,7 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		sp.Stages = append(sp.Stages, s)
 	}
 
@@ -213,7 +214,11 @@ func (b *Builder) buildManualJudgementStage(index int, s config.Stage) (*types.M
 
 func buildStageMetadata(s config.Stage, t string, index int, linear bool) types.StageMetadata {
 	refID := s.RefID
+	if s.ReliesOn == nil {
+		s.ReliesOn = []string{}
+	}
 	reliesOn := s.ReliesOn
+
 	if linear {
 		refID = fmt.Sprintf("%d", index)
 		if index > 0 {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1,9 +1,12 @@
 package builder_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/namely/k8s-pipeliner/pipeline/builder"
+	"github.com/namely/k8s-pipeliner/pipeline/builder/types"
 	"github.com/namely/k8s-pipeliner/pipeline/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,4 +50,33 @@ func TestBuilderAssignsPipelineConfiguration(t *testing.T) {
 	assert.True(t, spinnaker.KeepWaitingPipelines)
 	assert.True(t, spinnaker.LimitConcurrent)
 	assert.Equal(t, pipeline.Description, spinnaker.Description)
+}
+
+func TestBuilderAssignsRequisiteStageRefIds(t *testing.T) {
+	wd, _ := os.Getwd()
+	file := filepath.Join(wd, "testdata", "deployment.full.yml")
+
+	pipeline := &config.Pipeline{
+		DisableConcurrentExecutions: true,
+		KeepQueuedPipelines:         true,
+		Description:                 "fake description",
+		Stages: 										 []config.Stage{
+			{
+				Name: "Test Stage",
+				Deploy: &config.DeployStage{
+					Groups: []config.Group{
+						{
+							ManifestFile: file,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	builder := builder.New(pipeline)
+	spinnaker, err := builder.Pipeline()
+	require.NoError(t, err, "error generating pipeline json")
+
+	assert.Equal(t, []string{}, spinnaker.Stages[0].(*types.DeployStage).StageMetadata.RequisiteStageRefIds)
 }

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -52,31 +52,176 @@ func TestBuilderAssignsPipelineConfiguration(t *testing.T) {
 	assert.Equal(t, pipeline.Description, spinnaker.Description)
 }
 
-func TestBuilderAssignsRequisiteStageRefIds(t *testing.T) {
+func TestBuilderPipelineStages(t *testing.T) {
 	wd, _ := os.Getwd()
 	file := filepath.Join(wd, "testdata", "deployment.full.yml")
 
-	pipeline := &config.Pipeline{
-		DisableConcurrentExecutions: true,
-		KeepQueuedPipelines:         true,
-		Description:                 "fake description",
-		Stages: 										 []config.Stage{
-			{
-				Name: "Test Stage",
-				Deploy: &config.DeployStage{
-					Groups: []config.Group{
-						{
+	t.Run("Deploy stage is parsed correctly", func(t *testing.T) {
+		t.Run("Clusters are assigned", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Name: "Test Deploy Stage",
+						Deploy: &config.DeployStage{
+							Groups: []config.Group{
+								{
+									ManifestFile: file,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, "Test Deploy Stage", spinnaker.Stages[0].(*types.DeployStage).Name)
+			assert.Len(t, spinnaker.Stages[0].(*types.DeployStage).Clusters, 1)
+		})
+
+		t.Run("RequisiteStageRefIds defaults to an empty slice", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Deploy: &config.DeployStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{}, spinnaker.Stages[0].(*types.DeployStage).StageMetadata.RequisiteStageRefIds)
+		})
+
+		t.Run("RequisiteStageRefIds is assigned when ReliesOn is provided", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						ReliesOn: []string{"2"},
+						Deploy:   &config.DeployStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{"2"}, spinnaker.Stages[0].(*types.DeployStage).StageMetadata.RequisiteStageRefIds)
+		})
+	})
+
+	t.Run("RunJob stage is parsed correctly", func(t *testing.T) {
+		t.Run("Name is assigned", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Name: "Test RunJob Stage",
+						RunJob: &config.RunJobStage{
 							ManifestFile: file,
 						},
 					},
 				},
-			},
-		},
-	}
+			}
 
-	builder := builder.New(pipeline)
-	spinnaker, err := builder.Pipeline()
-	require.NoError(t, err, "error generating pipeline json")
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
 
-	assert.Equal(t, []string{}, spinnaker.Stages[0].(*types.DeployStage).StageMetadata.RequisiteStageRefIds)
+			assert.Equal(t, "Test RunJob Stage", spinnaker.Stages[0].(*types.RunJobStage).Name)
+		})
+
+		t.Run("RequisiteStageRefIds defaults to an empty slice", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						RunJob: &config.RunJobStage{
+							ManifestFile: file,
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{}, spinnaker.Stages[0].(*types.RunJobStage).StageMetadata.RequisiteStageRefIds)
+		})
+
+		t.Run("RequisiteStageRefIds is assigned when ReliesOn is provided", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						ReliesOn: []string{"2"},
+						RunJob: &config.RunJobStage{
+							ManifestFile: file,
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{"2"}, spinnaker.Stages[0].(*types.RunJobStage).StageMetadata.RequisiteStageRefIds)
+		})
+	})
+
+	t.Run("ManualJudgement stage is parsed correctly", func(t *testing.T) {
+		t.Run("Name is assigned", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Name:            "Test ManualJudgementStage Stage",
+						ManualJudgement: &config.ManualJudgementStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, "Test ManualJudgementStage Stage", spinnaker.Stages[0].(*types.ManualJudgementStage).Name)
+		})
+
+		t.Run("RequisiteStageRefIds defaults to an empty slice", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						ManualJudgement: &config.ManualJudgementStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{}, spinnaker.Stages[0].(*types.ManualJudgementStage).StageMetadata.RequisiteStageRefIds)
+		})
+
+		t.Run("RequisiteStageRefIds is assigned when ReliesOn is provided", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						ReliesOn:        []string{"2"},
+						ManualJudgement: &config.ManualJudgementStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, []string{"2"}, spinnaker.Stages[0].(*types.ManualJudgementStage).StageMetadata.RequisiteStageRefIds)
+		})
+	})
 }

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -29,7 +29,7 @@ type Trigger interface {
 // StageMetadata is the common components of a stage in spinnaker such as name
 type StageMetadata struct {
 	RefID                string         `json:"refId,omitempty"`
-	RequisiteStageRefIds []string       `json:"requisiteStageRefIds,omitempty"`
+	RequisiteStageRefIds []string       `json:"requisiteStageRefIds"`
 	Name                 string         `json:"name"`
 	Type                 string         `json:"type"`
 	Notifications        []Notification `json:"notifications,omitempty"`


### PR DESCRIPTION
Defaulting RequisiteStageRefIds to an empty slice. Without it, the spinnaker ui encounters a js error and prevents the edit actions modal from loading.

There's probably a better way to test this where I don't have to load the manifest file in the test, but I'm not familiar enough with it yet.