### PR TITLE
SRE-5212 - secretKeyRefs are not working in Spinnaker

### DIFF
--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -159,8 +159,8 @@ type Container struct {
 // variables
 type EnvFromSource struct {
 	Prefix          string                  `json:"prefix"`
-	ConfigMapSource *EnvFromConfigMapSource `json:"configMapRef"`
-	SecretSource    *EnvFromSecretSource    `json:"secretRef"`
+	ConfigMapSource *EnvFromConfigMapSource `json:"configMapRef,omitempty"`
+	SecretSource    *EnvFromSecretSource    `json:"secretRef,omitempty"`
 }
 
 // EnvFromConfigMapSource is used to pull in a configmap for key/value envVars


### PR DESCRIPTION
if you have both keys showing then it doesn't use either.