### PR TITLE
Adding a Log Line for when Marshaling Fails

### DIFF
--- a/pipeline/builder/kubernetes.go
+++ b/pipeline/builder/kubernetes.go
@@ -74,6 +74,7 @@ func (mp *ManifestParser) ContainersFromScaffold(scaffold config.ContainerScaffo
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, g, err := decode(b, nil, nil)
 	if err != nil {
+		fmt.Printf("Marshaling Failure: %s\n", path)
 		return nil, err
 	}
 


### PR DESCRIPTION
before (which deployment file did we fail on?):
```
 go run main.go create --linear pipeline.yml
json: error calling MarshalJSON for type *builder.Builder: yaml: line 61: did not find expected key
exit status 1
```
after:
```
go run cmd/k8s-pipeliner/main.go create --linear pipeline.yml
Marshaling Failure: /Users/shraykay/github/benefits-enrollment-api/manifests/benroll-api-namely/deployment.yml
json: error calling MarshalJSON for type *builder.Builder: yaml: line 61: did not find expected key
exit status 1```