### PR TITLE
Add webhook & parameter support

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -79,6 +79,15 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 		}
 	}
 
+	sp.Parameters = make([]types.Parameter, len(b.pipeline.Paramters))
+	for i, param := range b.pipeline.Paramters {
+		sp.Parameters[i] = types.Parameter{
+			Name:        param.Name,
+			Description: param.Description,
+			Required:    param.Required,
+		}
+	}
+
 	for stageIndex, stage := range b.pipeline.Stages {
 		var s types.Stage
 		var err error

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -17,6 +17,13 @@ var (
 	ErrOverrideContention = errors.New("builder: overrides were provided to a group that has multiple containers defined")
 )
 
+const (
+	// JenkinsTrigger is the name of the type in the spinnaker json for pipeline config for jenkins job triggers
+	JenkinsTrigger = "jenkins"
+	// WebhookTrigger is the name of the type in the spinnaker json for pipeline config for webhooks
+	WebhookTrigger = "webhook"
+)
+
 // Builder constructs a spinnaker pipeline JSON from a pipeliner config
 type Builder struct {
 	pipeline *config.Pipeline
@@ -45,26 +52,30 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 	}
 
 	sp.Notifications = buildNotifications(b.pipeline.Notifications)
-
-	sp.Triggers = []types.Trigger{}
+	sp.Triggers = make([]types.Trigger, 0)
 
 	for _, trigger := range b.pipeline.Triggers {
-		if trigger.Jenkins != nil {
-			jt := trigger.Jenkins
-
-			if jt.Enabled == nil {
-				jt.Enabled = newTrue()
-			}
-
+		if jt := trigger.Jenkins; jt != nil {
 			sp.Triggers = append(sp.Triggers, &types.JenkinsTrigger{
-				Enabled:      *jt.Enabled,
+				TriggerObject: types.TriggerObject{
+					Enabled: newDefaultTrue(jt.Enabled),
+					Type:    JenkinsTrigger,
+				},
+
 				Job:          jt.Job,
 				Master:       jt.Master,
 				PropertyFile: jt.PropertyFile,
-				Type:         "jenkins",
 			})
+		}
 
-			continue
+		if wh := trigger.Webhook; wh != nil {
+			sp.Triggers = append(sp.Triggers, &types.WebhookTrigger{
+				TriggerObject: types.TriggerObject{
+					Enabled: wh.Enabled,
+					Type:    WebhookTrigger,
+				},
+				Source: wh.Source,
+			})
 		}
 	}
 
@@ -277,7 +288,10 @@ func buildNotifications(notifications []config.Notification) []types.Notificatio
 	return nots
 }
 
-func newTrue() *bool {
-	b := true
-	return &b
+func newDefaultTrue(original *bool) bool {
+	if original == nil {
+		return true
+	}
+
+	return *original
 }

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -84,6 +84,7 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 		sp.Parameters[i] = types.Parameter{
 			Name:        param.Name,
 			Description: param.Description,
+			Default:     param.Default,
 			Required:    param.Required,
 		}
 	}

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -147,6 +147,29 @@ func TestBuilderPipelineStages(t *testing.T) {
 		})
 	})
 
+	t.Run("Parameter configuration is parsed correctly", func(t *testing.T) {
+		pipeline := &config.Pipeline{
+			Paramters: []config.Parameter{
+				{
+					Name:        "param1",
+					Description: "parameter description",
+					Required:    true,
+				},
+			},
+		}
+
+		b := builder.New(pipeline)
+		spinnaker, err := b.Pipeline()
+		require.NoError(t, err, "error generating pipeline json")
+
+		require.Len(t, spinnaker.Parameters, 1)
+
+		param := spinnaker.Parameters[0]
+		assert.Equal(t, true, param.Required)
+		assert.Equal(t, "parameter description", param.Description)
+		assert.Equal(t, "param1", param.Name)
+	})
+
 	t.Run("Deploy stage is parsed correctly", func(t *testing.T) {
 		t.Run("Clusters are assigned", func(t *testing.T) {
 			pipeline := &config.Pipeline{

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -153,6 +153,7 @@ func TestBuilderPipelineStages(t *testing.T) {
 				{
 					Name:        "param1",
 					Description: "parameter description",
+					Default:     "default value",
 					Required:    true,
 				},
 			},
@@ -168,6 +169,7 @@ func TestBuilderPipelineStages(t *testing.T) {
 		assert.Equal(t, true, param.Required)
 		assert.Equal(t, "parameter description", param.Description)
 		assert.Equal(t, "param1", param.Name)
+		assert.Equal(t, "default value", param.Default)
 	})
 
 	t.Run("Deploy stage is parsed correctly", func(t *testing.T) {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -114,11 +114,36 @@ func TestBuilderPipelineStages(t *testing.T) {
 
 			assert.Len(t, spinnaker.Triggers, 1)
 
-			assert.Equal(t, false, spinnaker.Triggers[0].(*types.JenkinsTrigger).Enabled)
-			assert.Equal(t, "My Job Name", spinnaker.Triggers[0].(*types.JenkinsTrigger).Job)
-			assert.Equal(t, "namely-jenkins", spinnaker.Triggers[0].(*types.JenkinsTrigger).Master)
-			assert.Equal(t, ".test-ci-properties", spinnaker.Triggers[0].(*types.JenkinsTrigger).PropertyFile)
-			assert.Equal(t, "jenkins", spinnaker.Triggers[0].(*types.JenkinsTrigger).Type)
+			jt := spinnaker.Triggers[0].(*types.JenkinsTrigger)
+			assert.Equal(t, false, jt.Enabled)
+			assert.Equal(t, "My Job Name", jt.Job)
+			assert.Equal(t, "namely-jenkins", jt.Master)
+			assert.Equal(t, ".test-ci-properties", jt.PropertyFile)
+			assert.Equal(t, "jenkins", jt.Type)
+		})
+
+		t.Run("WebhooksTrigger is configured correctly", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Triggers: []config.Trigger{
+					{
+						Webhook: &config.WebhookTrigger{
+							Source:  "this-is-a-test",
+							Enabled: true,
+						},
+					},
+				},
+			}
+
+			b := builder.New(pipeline)
+			spinnaker, err := b.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Len(t, spinnaker.Triggers, 1)
+
+			whTrigger := spinnaker.Triggers[0].(*types.WebhookTrigger)
+			assert.Equal(t, true, whTrigger.Enabled)
+			assert.Equal(t, builder.WebhookTrigger, whTrigger.Type)
+			assert.Equal(t, "this-is-a-test", whTrigger.Source)
 		})
 	})
 

--- a/pipeline/builder/types/triggers.go
+++ b/pipeline/builder/types/triggers.go
@@ -1,22 +1,5 @@
 package types
 
-// SpinnakerPipeline defines the fields for the top leve object of a spinnaker
-// pipeline. Mostly used for constructing JSON
-type SpinnakerPipeline struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Application string `json:"application,omitempty"`
-
-	Triggers      []Trigger      `json:"triggers"`
-	Stages        []Stage        `json:"stages"`
-	Notifications []Notification `json:"notifications"`
-
-	// Pipeline level config
-	LimitConcurrent      bool   `json:"limitConcurrent"`
-	KeepWaitingPipelines bool   `json:"keepWaitingPipelines"`
-	Description          string `json:"description"`
-}
-
 // Trigger is an interface to encompass multiple types of Spinnaker triggers
 type Trigger interface {
 	spinnakerTrigger()

--- a/pipeline/builder/types/triggers.go
+++ b/pipeline/builder/types/triggers.go
@@ -1,0 +1,65 @@
+package types
+
+// SpinnakerPipeline defines the fields for the top leve object of a spinnaker
+// pipeline. Mostly used for constructing JSON
+type SpinnakerPipeline struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Application string `json:"application,omitempty"`
+
+	Triggers      []Trigger      `json:"triggers"`
+	Stages        []Stage        `json:"stages"`
+	Notifications []Notification `json:"notifications"`
+
+	// Pipeline level config
+	LimitConcurrent      bool   `json:"limitConcurrent"`
+	KeepWaitingPipelines bool   `json:"keepWaitingPipelines"`
+	Description          string `json:"description"`
+}
+
+// Trigger is an interface to encompass multiple types of Spinnaker triggers
+type Trigger interface {
+	spinnakerTrigger()
+}
+
+// TriggerObject contains the fields that all triggers must have
+type TriggerObject struct {
+	Enabled bool   `json:"enabled"`
+	Type    string `json:"type"`
+}
+
+// StageMetadata is the common components of a stage in spinnaker such as name
+type StageMetadata struct {
+	RefID                string         `json:"refId,omitempty"`
+	RequisiteStageRefIds []string       `json:"requisiteStageRefIds"`
+	Name                 string         `json:"name"`
+	Type                 string         `json:"type"`
+	Notifications        []Notification `json:"notifications,omitempty"`
+	SendNotifications    bool           `json:"sendNotifications"`
+}
+
+// JenkinsTrigger constructs the JSON necessary to include a Jenkins trigger
+// for a spinnaker pipeline
+type JenkinsTrigger struct {
+	TriggerObject
+
+	Job          string `json:"job"`
+	Master       string `json:"master"`
+	PropertyFile string `json:"propertyFile"`
+}
+
+var _ Trigger = (*JenkinsTrigger)(nil)
+
+// Trigger implements Trigger
+func (t *JenkinsTrigger) spinnakerTrigger() {}
+
+// WebhookTrigger constructs the JSON for a webhook trigger in Spinnaker
+// pipelines
+type WebhookTrigger struct {
+	TriggerObject
+	Source string `json:"source"`
+}
+
+var _ Trigger = (*WebhookTrigger)(nil)
+
+func (t *WebhookTrigger) spinnakerTrigger() {}

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -4,6 +4,36 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// SpinnakerPipeline defines the fields for the top leve object of a spinnaker
+// pipeline. Mostly used for constructing JSON
+type SpinnakerPipeline struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Application string `json:"application,omitempty"`
+
+	Triggers      []Trigger      `json:"triggers"`
+	Stages        []Stage        `json:"stages"`
+	Notifications []Notification `json:"notifications"`
+
+	// Pipeline level config
+	LimitConcurrent      bool   `json:"limitConcurrent"`
+	KeepWaitingPipelines bool   `json:"keepWaitingPipelines"`
+	Description          string `json:"description"`
+
+	Parameters []Parameter `json:"parameterConfig"`
+}
+
+// Parameter is a parameter declaration for a pipeline config
+type Parameter struct {
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Required    bool   `json:"required"`
+
+	// TODO(bobbytables): Allow configuring parameter options
+	HasOptions bool          `json:"hasOptions"`
+	Options    []interface{} `json:"options"`
+}
+
 // Stage is an interface to represent a Stage struct such as RunJob or Deploy
 type Stage interface {
 	spinnakerStage()

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -27,6 +27,7 @@ type SpinnakerPipeline struct {
 type Parameter struct {
 	Description string `json:"description"`
 	Name        string `json:"name"`
+	Default     string `json:"default"`
 	Required    bool   `json:"required"`
 
 	// TODO(bobbytables): Allow configuring parameter options

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -4,53 +4,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// SpinnakerPipeline defines the fields for the top leve object of a spinnaker
-// pipeline. Mostly used for constructing JSON
-type SpinnakerPipeline struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Application string `json:"application,omitempty"`
-
-	Triggers      []Trigger      `json:"triggers"`
-	Stages        []Stage        `json:"stages"`
-	Notifications []Notification `json:"notifications"`
-
-	// Pipeline level config
-	LimitConcurrent      bool   `json:"limitConcurrent"`
-	KeepWaitingPipelines bool   `json:"keepWaitingPipelines"`
-	Description          string `json:"description"`
-}
-
-// Trigger is an interface to encompass multiple types of Spinnaker triggers
-type Trigger interface {
-	spinnakerTrigger()
-}
-
-// StageMetadata is the common components of a stage in spinnaker such as name
-type StageMetadata struct {
-	RefID                string         `json:"refId,omitempty"`
-	RequisiteStageRefIds []string       `json:"requisiteStageRefIds"`
-	Name                 string         `json:"name"`
-	Type                 string         `json:"type"`
-	Notifications        []Notification `json:"notifications,omitempty"`
-	SendNotifications    bool           `json:"sendNotifications"`
-}
-
-// JenkinsTrigger constructs the JSON necessary to include a Jenkins trigger
-// for a spinnaker pipeline
-type JenkinsTrigger struct {
-	Enabled      bool   `json:"enabled"`
-	Job          string `json:"job"`
-	Master       string `json:"master"`
-	PropertyFile string `json:"propertyFile"`
-	Type         string `json:"type"`
-}
-
-var _ Trigger = &JenkinsTrigger{}
-
-// Trigger implements Trigger
-func (t *JenkinsTrigger) spinnakerTrigger() {}
-
 // Stage is an interface to represent a Stage struct such as RunJob or Deploy
 type Stage interface {
 	spinnakerStage()

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -43,6 +43,7 @@ type Pipeline struct {
 type Parameter struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
+	Default     string `yaml:"default"`
 	Required    bool   `yaml:"required"`
 }
 

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -53,6 +53,7 @@ type ImageDescription struct {
 // spinnaker triggers such as jenkins or docker registry
 type Trigger struct {
 	Jenkins *JenkinsTrigger `yaml:"jenkins"`
+	Webhook *WebhookTrigger `yaml:"webhook"`
 }
 
 // JenkinsTrigger has all of the fields defining how a trigger
@@ -62,6 +63,12 @@ type JenkinsTrigger struct {
 	Master       string `yaml:"master"`
 	PropertyFile string `yaml:"propertyFile"`
 	Enabled      *bool  `yaml:"enabled"`
+}
+
+// WebhookTrigger defines how a webhook can trigger a pipeline execution
+type WebhookTrigger struct {
+	Enabled bool   `yaml:"enabled"`
+	Source  string `yaml:"source"`
 }
 
 // Stage is an individual stage within a spinnaker pipeline

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -30,11 +30,20 @@ type Pipeline struct {
 	Triggers          []Trigger          `yaml:"triggers"`
 	Stages            []Stage            `yaml:"stages"`
 	ImageDescriptions []ImageDescription `yaml:"imageDescriptions"`
-	Notifications     []Notification     `yaml:"notifications"`
 
 	DisableConcurrentExecutions bool   `yaml:"disableConcurrentExecutions"`
 	KeepQueuedPipelines         bool   `yaml:"keepQueuedPipelines"`
 	Description                 string `yaml:"description"`
+
+	Notifications []Notification `yaml:"notifications"`
+	Paramters     []Parameter    `yaml:"parameters"`
+}
+
+// Parameter defines a single parameter in a pipeline config
+type Parameter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
 }
 
 // ImageDescription contains the description of an image that can be referenced

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -23,6 +23,9 @@ triggers:
     master: "jenkins"
     propertyFile: "build.properties"
     enabled: true
+- webhook:
+    source: "random-string"
+    enabled: true
 imageDescriptions:
   - name: main-image
     account: "namely-registry"

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -17,6 +17,12 @@ notifications:
       pipeline.failed: |
         The stage has failed!
 
+parameters:
+  - name: "random"
+    description: "random description"
+    required: true
+    default: "hello-world"
+
 triggers:
 - jenkins:
     job: "Example/job/master"


### PR DESCRIPTION
This allows you to configure pipelines with Webhook triggers and parameters. This makes pipeline easier to kick off with HTTP requests instead of relying on Jenkins to finish builds. You can kick off any pipeline with parameters on a specific URL.