### PR TITLE
Add support for scale manifest stage

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -154,6 +154,11 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 			stageIndex = stageIndex + 1
 		}
 
+		if stage.ScaleManifest != nil {
+			s, err = b.buildScaleManifestStage(stageIndex, stage)
+			stageIndex = stageIndex + 1
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +432,20 @@ func (b *Builder) buildV2DeleteManifestStage(index int, s config.Stage) (*types.
 	}
 
 	return dms, nil
+}
 
+func (b *Builder) buildScaleManifestStage(index int, s config.Stage) (*types.ScaleManifestStage, error) {
+	stage := &types.ScaleManifestStage{
+		StageMetadata: buildStageMetadata(s, "scaleManifest", index, b.isLinear),
+		Account:       s.Account,
+		CloudProvider: "kubernetes",
+		Kind:          s.ScaleManifest.Kind,
+		Location:      s.ScaleManifest.Namespace,
+		ManifestName:  fmt.Sprintf("%s %s", s.ScaleManifest.Kind, s.ScaleManifest.Name),
+		Replicas:      s.ScaleManifest.Replicas,
+	}
+
+	return stage, nil
 }
 
 // As of right now, this tool only supports deploying one server group at a time from a

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -15,7 +15,7 @@ func Int64(i int64) *int64 {
 	return &i
 }
 
-// SpinnakerPipeline defines the fields for the top leve object of a spinnaker
+// SpinnakerPipeline defines the fields for the top level object of a spinnaker
 // pipeline. Mostly used for constructing JSON
 type SpinnakerPipeline struct {
 	AppConfig   map[string]interface{} `json:"appConfig"`
@@ -96,6 +96,28 @@ type DeleteManifestStage struct {
 func (ms DeleteManifestStage) spinnakerStage() {}
 
 var _ Stage = DeleteManifestStage{}
+
+// ScaleManifestStage is a struct representing the v2 Spinnaker Scale Manifest stage
+type ScaleManifestStage struct {
+	StageMetadata
+
+	Account       string `json:"account"`
+	CloudProvider string `json:"cloudProvider"`
+	Kind          string `json:"kind"`
+
+	// Location means kubernetes namespace
+	Location string `json:"location"`
+
+	// Name is used when deleting a manifest by kind / name. The format for this
+	// needs to be "kind manifestName", For example: "deployment application-deploy"
+	ManifestName string `json:"manifestName,omitempty"`
+
+	Replicas int `json:"replicas"`
+}
+
+func (ms ScaleManifestStage) spinnakerStage() {}
+
+var _ Stage = ScaleManifestStage{}
 
 // LabelSelectors encompasses all of the labels you're selecting on
 type LabelSelectors struct {

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -96,6 +96,7 @@ type Stage struct {
 	ManualJudgement         *ManualJudgementStage    `yaml:"manualJudgement,omitempty"`
 	DeployEmbeddedManifests *DeployEmbeddedManifests `yaml:"deployEmbeddedManifests,omitempty"`
 	DeleteEmbeddedManifest  *DeleteEmbeddedManifest  `yaml:"deleteEmbeddedManifest,omitempty"`
+	ScaleManifest           *ScaleManifest           `yaml:"scaleManifest,omitempty"`
 }
 
 // Notification config from pipeline configuration on a stage or pipeline
@@ -199,6 +200,15 @@ type Moniker struct {
 	Cluster string `yaml:"cluster"`
 	Detail  string `yaml:"detail"`
 	Stack   string `yaml:"stack"`
+}
+
+// ScaleManifest is a Kubernetes V2 provider stage configuration
+// for scaling a Kubernetes object
+type ScaleManifest struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+	Replicas  int    `yaml:"replicas"`
 }
 
 // ContainerOverrides are used to override a containers values for simple

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -35,6 +35,13 @@ stages:
       - file: test-deployment.yml
       - file: test-configmap.yml
 - account: ops-k8s
+  name: "Scale Up"
+  scaleManifest:
+    namespace: "looker"
+    kind: "deployment"
+    name: "looker"
+    replicas: 5
+- account: ops-k8s
   name: "Delete INT"
   deleteEmbeddedManifest:
     file: test-deployment.yml


### PR DESCRIPTION
Adding support for this scale manifest stage:
![image](https://user-images.githubusercontent.com/674003/46831830-6f2d3680-cd72-11e8-964a-d5762150f6fd.png)

Spinnaker generated json looks like:
![image](https://user-images.githubusercontent.com/674003/46831846-84a26080-cd72-11e8-8b7d-96c30507572a.png)

Looker deployments will want to use this because the current method is to deploy 1 pod, let migrations run, and then manually scale up to 5. There's no way to run Looker migrations as a one-off job at the moment due to Looker baking migrations in into their jar.
