### PR TITLE
SRESOLD-1090 - adding timeouts to spinnaker stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ stages:
   reliesOn:
     - "2"
   manualJudgement:
+    timeoutHours: 48
     failPipeline: true
     instructions: |
       If this stage has completed QA, press proceed.

--- a/cmd/k8s-pipeliner/main.go
+++ b/cmd/k8s-pipeliner/main.go
@@ -38,6 +38,10 @@ func main() {
 					Name:  "v2",
 					Usage: "Create your manifests with the v2 kubernetes provider",
 				},
+				cli.IntFlag{
+					Name:  "timeout",
+					Usage: "override the default 72 hour timeout (unit: int)",
+				},
 			},
 		},
 		{
@@ -69,7 +73,7 @@ func createAction(ctx *cli.Context) error {
 		return err
 	}
 
-	builder := builder.New(p, builder.WithV2Provider(ctx.Bool("v2")), builder.WithLinear(ctx.Bool("linear")))
+	builder := builder.New(p, builder.WithV2Provider(ctx.Bool("v2")), builder.WithLinear(ctx.Bool("linear")), builder.WithTimeoutOverride(ctx.Int("timeout")))
 	return json.NewEncoder(os.Stdout).Encode(builder)
 }
 

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -508,7 +508,7 @@ func (b *Builder) buildDeployStage(index int, s config.Stage) (*types.DeployStag
 			VolumeSources:         mg.VolumeSources,
 
 			// TODO(bobbytables): allow these to be configurable
-			Events: []interface{}{},
+			Events:                         []interface{}{},
 			InterestingHealthProviderNames: []string{"KubernetesContainer", "KubernetesPod"},
 			Provider:                       "kubernetes",
 			CloudProvider:                  "kubernetes",
@@ -525,10 +525,15 @@ func (b *Builder) buildDeployStage(index int, s config.Stage) (*types.DeployStag
 func (b *Builder) buildManualJudgementStage(index int, s config.Stage) (*types.ManualJudgementStage, error) {
 	mjs := &types.ManualJudgementStage{
 		StageMetadata: buildStageMetadata(s, "manualJudgment", index, b.isLinear),
+		FailPipeline:  s.ManualJudgement.FailPipeline,
+		Instructions:  s.ManualJudgement.Instructions,
+		Inputs:        s.ManualJudgement.Inputs,
+	}
 
-		FailPipeline: s.ManualJudgement.FailPipeline,
-		Instructions: s.ManualJudgement.Instructions,
-		Inputs:       s.ManualJudgement.Inputs,
+	// if the timeout is actually set
+	if s.ManualJudgement.Timeout != 0 {
+		mjs.OverrideTimeout = true
+		mjs.StageTimeoutMS = int64(s.ManualJudgement.Timeout) * int64(3600000)
 	}
 
 	return mjs, nil

--- a/pipeline/builder/options.go
+++ b/pipeline/builder/options.go
@@ -25,3 +25,10 @@ func WithV2Provider(v bool) OptFunc {
 		b.v2Provider = v
 	}
 }
+
+// WithTimeoutOverride overrides every stage's default 72 hour timeout
+func WithTimeoutOverride(hours int) OptFunc {
+	return func(b *Builder) {
+		b.timeoutHours = hours
+	}
+}

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -188,9 +188,11 @@ var _ Stage = DeployStage{}
 type ManualJudgementStage struct {
 	StageMetadata
 
-	FailPipeline bool     `json:"failPipeline"`
-	Instructions string   `json:"instructions"`
-	Inputs       []string `json:"inputs,omitempty"`
+	FailPipeline    bool     `json:"failPipeline"`
+	Instructions    string   `json:"instructions"`
+	Inputs          []string `json:"inputs,omitempty"`
+	OverrideTimeout bool     `json:"overrideTimeout,omitempty"`
+	StageTimeoutMS  int64    `json:"stageTimeoutMs,omitempty"`
 }
 
 func (mjs ManualJudgementStage) spinnakerStage() {}

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -172,6 +172,7 @@ type ManualJudgementStage struct {
 	FailPipeline bool     `yaml:"failPipeline"`
 	Instructions string   `yaml:"instructions"`
 	Inputs       []string `yaml:"inputs"`
+	Timeout      int      `yaml:"timeoutHours,omitempty"`
 }
 
 // ManifestFile represents a single manifest file

--- a/pipeline/config/config_test.go
+++ b/pipeline/config/config_test.go
@@ -23,11 +23,17 @@ func TestNewConfig(t *testing.T) {
 	require.Len(t, cfg.Triggers, 1)
 	require.Equal(t, "nginx/job/master", cfg.Triggers[0].Jenkins.Job)
 
-	require.Len(t, cfg.Stages, 1)
+	require.Len(t, cfg.Stages, 3)
 
 	stage := cfg.Stages[0]
 	require.NotNil(t, stage.DeployEmbeddedManifests)
 	assert.Equal(t, stage.DeployEmbeddedManifests.Files[0].File, "manifests/nginx-deployment.yml")
 	assert.Equal(t, stage.Name, "Deploy nginx")
 	assert.Equal(t, stage.Account, "int-k8s")
+	stage2 := cfg.Stages[1]
+	require.NotNil(t, stage2.ManualJudgement)
+	assert.Equal(t, stage2.ManualJudgement.Timeout, 100)
+	stage3 := cfg.Stages[2]
+	require.NotNil(t, stage3.ManualJudgement)
+	assert.Equal(t, stage3.ManualJudgement.Timeout, 0)
 }

--- a/pipeline/config/testdata/pipeline.full.yaml
+++ b/pipeline/config/testdata/pipeline.full.yaml
@@ -11,3 +11,16 @@ stages:
   deployEmbeddedManifests:
     files:
     - file: manifests/nginx-deployment.yml
+- account: int-k8s
+  name: Deploy to staging-k8s?
+  manualJudgement:
+    failPipeline: true
+    instructions: Should this pipeline continue?
+    inputs: []
+    timeoutHours: 100
+- account: int-k8s
+  name: Deploy to staging-k8s?
+  manualJudgement:
+    failPipeline: true
+    instructions: Should this pipeline continue?
+    inputs: []


### PR DESCRIPTION
adding timeout overrides to the manual judgement stages (which are by default 72 hours)