### PR TITLE
Adding account override command line flag

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -59,10 +59,11 @@ const (
 type Builder struct {
 	pipeline *config.Pipeline
 
-	isLinear     bool
-	basePath     string
-	v2Provider   bool
-	timeoutHours int
+	isLinear         bool
+	basePath         string
+	v2Provider       bool
+	timeoutHours     int
+	overrideAccounts map[string]string
 }
 
 // New initializes a new builder for a pipeline config
@@ -127,6 +128,11 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 	for _, stage := range b.pipeline.Stages {
 		var s types.Stage
 		var err error
+
+		// if the account has an override, switch the account name
+		if account, ok := b.overrideAccounts[stage.Account]; ok {
+			stage.Account = account
+		}
 
 		if b.v2Provider {
 			if stage.RunJob != nil {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1,6 +1,7 @@
 package builder_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -228,7 +229,60 @@ func TestBuilderPipelineStages(t *testing.T) {
 			spinnaker, err := builder.Pipeline()
 			require.NoError(t, err, "error generating pipeline json")
 			assert.Equal(t, "Test V2 Deploy Stage", spinnaker.Stages[0].(*types.ManifestStage).Name)
+		})
 
+		t.Run("Test Account Override is working", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{Account: "int-k8s",
+						Name: "Test Deploy Stage",
+						Deploy: &config.DeployStage{
+							Groups: []config.Group{
+								{
+									ManifestFile: file,
+									PodOverrides: &config.PodOverrides{
+										Annotations: map[string]string{"hello": "world"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline, builder.WithLinear(true), builder.WithV2Provider(true), builder.WithAccountOverride(map[string]string{"int-k8s": "int"}))
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+			assert.Equal(t, "Test Deploy Stage", spinnaker.Stages[0].(*types.ManifestStage).Name)
+			assert.Equal(t, "int", spinnaker.Stages[0].(*types.ManifestStage).Account)
+			fmt.Println(spinnaker.Stages[0].(*types.ManifestStage).Account)
+		})
+
+		t.Run("Test account override ignores other accounts", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{Account: "int-k8s",
+						Name: "Test Deploy Stage",
+						Deploy: &config.DeployStage{
+							Groups: []config.Group{
+								{
+									ManifestFile: file,
+									PodOverrides: &config.PodOverrides{
+										Annotations: map[string]string{"hello": "world"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline, builder.WithLinear(true), builder.WithV2Provider(true), builder.WithAccountOverride(map[string]string{"staging-k8s": "staging"}))
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+			assert.Equal(t, "Test Deploy Stage", spinnaker.Stages[0].(*types.ManifestStage).Name)
+			assert.Equal(t, "int-k8s", spinnaker.Stages[0].(*types.ManifestStage).Account)
+			fmt.Println(spinnaker.Stages[0].(*types.ManifestStage).Account)
 		})
 
 		t.Run("RequisiteStageRefIds defaults to an empty slice", func(t *testing.T) {

--- a/pipeline/builder/options.go
+++ b/pipeline/builder/options.go
@@ -32,3 +32,10 @@ func WithTimeoutOverride(hours int) OptFunc {
 		b.timeoutHours = hours
 	}
 }
+
+// WithAccountOverride lets you override an account with a different account
+func WithAccountOverride(accounts map[string]string) OptFunc {
+	return func(b *Builder) {
+		b.overrideAccounts = accounts
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -89,6 +89,14 @@
 			"revisionTime": "2018-09-20T16:51:51Z"
 		},
 		{
+
+			"checksumSHA1": "u020y2UAnCwdHgnM0GzBGpVNE58=",
+			"origin": "github.com/namely/k8s-pipeliner/vendor/github.com/namely/k8s-pipeliner/pipeline/config",
+			"path": "github.com/namely/k8s-pipeliner/pipeline/config",
+			"revision": "64bbb85fb6e1391550e69f7f4d8d871d60e31b4e",
+			"revisionTime": "2018-12-04T15:54:44Z"
+		},
+		{
 			"checksumSHA1": "ljd3FhYRJ91cLZz3wsH9BQQ2JbA=",
 			"path": "github.com/pkg/errors",
 			"revision": "816c9085562cd7ee03e7f8188a1cfd942858cded",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -83,18 +83,16 @@
 			"revisionTime": "2018-08-09T22:11:04Z"
 		},
 		{
-			"checksumSHA1": "UdgOEimjVVIIvrSjTGzD4oDaYjI=",
+			"checksumSHA1": "kWc69gh2NaXdo63gbfp77LTXiS4=",
 			"path": "github.com/namely/k8s-configurator",
 			"revision": "db775ef189eb77fdde753d1f0c447fff1f8a6e9b",
 			"revisionTime": "2018-09-20T16:51:51Z"
 		},
 		{
-
-			"checksumSHA1": "u020y2UAnCwdHgnM0GzBGpVNE58=",
-			"origin": "github.com/namely/k8s-pipeliner/vendor/github.com/namely/k8s-pipeliner/pipeline/config",
+			"checksumSHA1": "RS/TqWQGmuk6pxcdNXtlM4+mALU=",
 			"path": "github.com/namely/k8s-pipeliner/pipeline/config",
-			"revision": "64bbb85fb6e1391550e69f7f4d8d871d60e31b4e",
-			"revisionTime": "2018-12-04T15:54:44Z"
+			"revision": "4a76cecf31ac0d03e372bd08ce3ba1826ed39ed5",
+			"revisionTime": "2019-01-16T19:06:37Z"
 		},
 		{
 			"checksumSHA1": "ljd3FhYRJ91cLZz3wsH9BQQ2JbA=",
@@ -210,10 +208,10 @@
 			"revisionTime": "2018-01-25T14:14:21Z"
 		},
 		{
-			"checksumSHA1": "qOmvuDm+F+2nQQecUZBVkZrTn6Y=",
+			"checksumSHA1": "QqDq2x8XOU7IoOR98Cx1eiV5QY8=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "d670f9405373e636a5a2765eea47fac0c9bc91a4",
-			"revisionTime": "2018-01-09T11:43:31Z"
+			"revision": "51d6538a90f86fe93ac480b35f37b2be17fef232",
+			"revisionTime": "2018-11-15T11:05:04Z"
 		},
 		{
 			"checksumSHA1": "xwvGTst/xgcrHZB2fy3PhWHAXAk=",


### PR DESCRIPTION
if you type `k8s-pipeline create test-pipeline --linear --override=int-k8s:ops` any stage that has `int-k8s` listed becomes `ops`.