### PR TITLE
Support parsing empty manifests in embedded files

### DIFF
--- a/pipeline/builder/kubernetes.go
+++ b/pipeline/builder/kubernetes.go
@@ -118,7 +118,7 @@ func (mp *ManifestParser) ManifestsFromFile(path string) ([]runtime.Object, erro
 			// second condition accounts for empty YAML object (eg: \n --- \n --- etc.)
 			// --> we'll just keep calm on chive on
 			if strings.Contains(err.Error(), "missing in 'null'") {
-				break
+				continue
 			}
 			// error decoding
 			fmt.Printf("Failed to decode: %v", err)

--- a/pipeline/builder/testdata/multiple-documents.yml
+++ b/pipeline/builder/testdata/multiple-documents.yml
@@ -1,3 +1,5 @@
+---
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -26,6 +28,10 @@ spec:
               name: nginx-cm
               key: hello
 ---
+
+
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,6 +42,9 @@ spec:
   ports:
     - name: http
       port: 80
+---
+# This is a comment
+
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule


### PR DESCRIPTION
Pipeliner was exiting when it reached the first empty manifest. This PR will allow us to parse the file until the very end

```
...
---
# Anything below wont here be included in pipeline
---
apiVersion: apps/v1beta1
...
```