### PR TITLE
update example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,9 @@ stages:
       detail: detail
       stack: stack
     files:
-      - manifests/deployment.yml
-      - manifests/service.yml
-      - manifests/migrate-job.yml
+      - file: manifests/deployment.yml
+      - file: manifests/service.yml
+      - file: manifests/migrate-job.yml
     configuratorFiles:
       - file: test-configurator.yml
         env: superOps


### PR DESCRIPTION
the last `deployEmbeddedManifests` example of the readme will generate the following unmarshall error:
```
cannot unmarshal !!str `manifes...` into config.ManifestFile
```
this PR fixes the yaml syntax to make the error go away.