### PR TITLE
PP-2369: Override StageTimeoutMs and Specify Options

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -129,7 +129,7 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 			Required:    param.Required,
 		}
 
-		if param.HasOptions && len(param.Options) > 0 {
+		if len(param.Options) > 0 {
 			sp.Parameters[i].HasOptions = true
 			foundDefaultValue := param.Default == ""
 			for _, val := range param.Options {

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -442,7 +442,7 @@ func (b *Builder) defaultManifestStage(index int, s config.Stage) *types.Manifes
 	markUnstableAsSuccessful := setDefaultIfNil(s.DeployEmbeddedManifests.MarkUnstableAsSuccessful, false)
 	waitForCompletion := setDefaultIfNil(s.DeployEmbeddedManifests.WaitForCompletion, true)
 
-	return &types.ManifestStage{
+	stage := &types.ManifestStage{
 		StageMetadata:           buildStageMetadata(s, "deployManifest", index, b.isLinear),
 		Account:                 s.Account,
 		CloudProvider:           "kubernetes",
@@ -460,6 +460,13 @@ func (b *Builder) defaultManifestStage(index int, s config.Stage) *types.Manifes
 		MarkUnstableAsSuccessful:      &markUnstableAsSuccessful,
 		WaitForCompletion:             &waitForCompletion,
 	}
+
+	if s.DeployEmbeddedManifests.StageTimeoutMS > 0 {
+		stage.OverrideTimeout = true
+		stage.StageTimeoutMS = s.DeployEmbeddedManifests.StageTimeoutMS
+	}
+
+	return stage
 }
 
 func (b *Builder) buildV2RunJobStage(index int, s config.Stage) (*types.ManifestStage, error) {

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -128,6 +128,20 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 			Default:     param.Default,
 			Required:    param.Required,
 		}
+
+		if param.HasOptions && len(param.Options) > 0 {
+			sp.Parameters[i].HasOptions = true
+			foundDefaultValue := param.Default == ""
+			for _, val := range param.Options {
+				foundDefaultValue = foundDefaultValue || param.Default == val.Value
+				sp.Parameters[i].Options = append(sp.Parameters[i].Options, types.Option{
+					Value: val.Value,
+				})
+			}
+			if !foundDefaultValue {
+				return sp, errors.New("builder: the specified default value is not one of the options")
+			}
+		}
 	}
 
 	var stageIndex = 0

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -180,7 +180,6 @@ func TestBuilderPipelineStages(t *testing.T) {
 						Name:        "param1",
 						Description: "parameter description",
 						Required:    true,
-						HasOptions:  true,
 						Options: []config.Option{
 							{
 								Value: "opt1",
@@ -208,13 +207,48 @@ func TestBuilderPipelineStages(t *testing.T) {
 			assert.Equal(t, "opt2", param.Options[1].Value)
 		})
 
+		t.Run("With options and a default value", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Parameters: []config.Parameter{
+					{
+						Name:        "param1",
+						Description: "parameter description",
+						Default:     "opt1",
+						Required:    true,
+						Options: []config.Option{
+							{
+								Value: "opt1",
+							},
+							{
+								Value: "opt2",
+							},
+						},
+					},
+				},
+			}
+
+			b := builder.New(pipeline)
+			spinnaker, err := b.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			require.Len(t, spinnaker.Parameters, 1)
+
+			param := spinnaker.Parameters[0]
+			assert.Equal(t, true, param.Required)
+			assert.Equal(t, "parameter description", param.Description)
+			assert.Equal(t, "param1", param.Name)
+			assert.Equal(t, "opt1", param.Default)
+			assert.True(t, param.HasOptions)
+			assert.Equal(t, "opt1", param.Options[0].Value)
+			assert.Equal(t, "opt2", param.Options[1].Value)
+		})
+
 		t.Run("With error handling for mismatched option and default values", func(t *testing.T) {
 			pipeline := &config.Pipeline{
 				Parameters: []config.Parameter{
 					{
-						Name:       "param1",
-						Default:    "optN",
-						HasOptions: true,
+						Name:    "param1",
+						Default: "optN",
 						Options: []config.Option{
 							{
 								Value: "opt1",

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -44,9 +44,13 @@ type Parameter struct {
 	Default     string `json:"default"`
 	Required    bool   `json:"required"`
 
-	// TODO(bobbytables): Allow configuring parameter options
-	HasOptions bool          `json:"hasOptions"`
-	Options    []interface{} `json:"options"`
+	HasOptions bool     `json:"hasOptions,omitempty"`
+	Options    []Option `json:"options,omitempty"`
+}
+
+// Option contains the value of the option in a given pipeline parameter
+type Option struct {
+	Value string `json:"value,omitempty"`
 }
 
 // Stage is an interface to represent a Stage struct such as RunJob or Deploy

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -75,6 +75,8 @@ type ManifestStage struct {
 	FailPipeline                  *bool `json:"failPipeline,omitempty"`
 	MarkUnstableAsSuccessful      *bool `json:"markUnstableAsSuccessful,omitempty"`
 	WaitForCompletion             *bool `json:"waitForCompletion,omitempty"`
+	OverrideTimeout               bool  `json:"overrideTimeout,omitempty"`
+	StageTimeoutMS                int64 `json:"stageTimeoutMs,omitempty"`
 }
 
 func (ms ManifestStage) spinnakerStage() {}

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -43,10 +43,17 @@ type Pipeline struct {
 
 // Parameter defines a single parameter in a pipeline config
 type Parameter struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
-	Default     string `yaml:"default"`
-	Required    bool   `yaml:"required"`
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Default     string   `yaml:"default"`
+	Required    bool     `yaml:"required"`
+	HasOptions  bool     `yaml:"hasOptions"`
+	Options     []Option `yaml:"options"`
+}
+
+// Option contains the option value of a single parameter in a pipeline config
+type Option struct {
+	Value string `yaml:"value"`
 }
 
 // ImageDescription contains the description of an image that can be referenced

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -250,6 +250,7 @@ type DeployEmbeddedManifests struct {
 	FailPipeline                  *bool `yaml:"failPipeline,omitempty"`
 	MarkUnstableAsSuccessful      *bool `yaml:"markUnstableAsSuccessful,omitempty"`
 	WaitForCompletion             *bool `yaml:"waitForCompletion,omitempty"`
+	StageTimeoutMS                int64 `yaml:"stageTimeoutMs,omitempty"`
 }
 
 // DeleteEmbeddedManifest represents a single resource to be deleted

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -47,7 +47,6 @@ type Parameter struct {
 	Description string   `yaml:"description"`
 	Default     string   `yaml:"default"`
 	Required    bool     `yaml:"required"`
-	HasOptions  bool     `yaml:"hasOptions"`
 	Options     []Option `yaml:"options"`
 }
 


### PR DESCRIPTION
Spinnaker allows you to override the default timeout of 30 minutes on deploy embedded manifest stages, but k8s-pipeliner does. So whenever a new commit comes in, the timeout gets reset to 30 minutes. This should give us the ability to specify overriding stage timeouts when we want to and keep them overridden.

I'm also adding the ability to actually specify an option list in your spinnaker parameters