### PR TITLE
PP-3113: override default timeouts; give spinnaker this ability too

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -520,6 +520,7 @@ func (b *Builder) defaultManifestStage(index int, s config.Stage) *types.Manifes
 	failPipeline := setDefaultIfNil(s.DeployEmbeddedManifests.FailPipeline, true)
 	markUnstableAsSuccessful := setDefaultIfNil(s.DeployEmbeddedManifests.MarkUnstableAsSuccessful, false)
 	waitForCompletion := setDefaultIfNil(s.DeployEmbeddedManifests.WaitForCompletion, true)
+	timeoutMs := setDefaultIntIfNil(s.DeployEmbeddedManifests.StageTimeoutMS, 1800000) // defaults to 30 minutes
 
 	stage := &types.ManifestStage{
 		StageMetadata:           buildStageMetadata(s, "deployManifest", index, b.isLinear),
@@ -538,11 +539,8 @@ func (b *Builder) defaultManifestStage(index int, s config.Stage) *types.Manifes
 		FailPipeline:                  &failPipeline,
 		MarkUnstableAsSuccessful:      &markUnstableAsSuccessful,
 		WaitForCompletion:             &waitForCompletion,
-	}
-
-	if s.DeployEmbeddedManifests.StageTimeoutMS > 0 {
-		stage.OverrideTimeout = true
-		stage.StageTimeoutMS = s.DeployEmbeddedManifests.StageTimeoutMS
+		OverrideTimeout:               true,
+		StageTimeoutMS:                timeoutMs,
 	}
 
 	return stage
@@ -623,6 +621,7 @@ func (b *Builder) buildRunSpinnakerPipelineStage(index int, s config.Stage) (*ty
 	failPipeline := setDefaultIfNil(s.RunSpinnakerPipeline.FailPipeline, true)
 	markUnstableAsSuccessful := setDefaultIfNil(s.RunSpinnakerPipeline.MarkUnstableAsSuccessful, false)
 	waitForCompletion := setDefaultIfNil(s.RunSpinnakerPipeline.WaitForCompletion, true)
+	timeoutMs := setDefaultIntIfNil(s.RunSpinnakerPipeline.StageTimeoutMS, 3600000) // defaults to 1 hour
 
 	stage := &types.RunSpinnakerPipelineStage{
 		StageMetadata:                 buildStageMetadata(s, "pipeline", index, b.isLinear),
@@ -635,6 +634,8 @@ func (b *Builder) buildRunSpinnakerPipelineStage(index int, s config.Stage) (*ty
 		FailPipeline:                  &failPipeline,
 		MarkUnstableAsSuccessful:      &markUnstableAsSuccessful,
 		WaitForCompletion:             &waitForCompletion,
+		OverrideTimeout:               true,
+		StageTimeoutMS:                timeoutMs,
 	}
 
 	for _, p := range s.RunSpinnakerPipeline.PipelineParameters {
@@ -649,6 +650,15 @@ func setDefaultIfNil(givenValue *bool, defaultValue bool) bool {
 	retValue := defaultValue
 	if givenValue != nil {
 		retValue = *(givenValue)
+	}
+
+	return retValue
+}
+
+func setDefaultIntIfNil(givenValue int64, defaultValue int64) int64 {
+	retValue := defaultValue
+	if givenValue != 0 {
+		retValue = givenValue
 	}
 
 	return retValue

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -520,7 +520,7 @@ func (b *Builder) defaultManifestStage(index int, s config.Stage) *types.Manifes
 	failPipeline := setDefaultIfNil(s.DeployEmbeddedManifests.FailPipeline, true)
 	markUnstableAsSuccessful := setDefaultIfNil(s.DeployEmbeddedManifests.MarkUnstableAsSuccessful, false)
 	waitForCompletion := setDefaultIfNil(s.DeployEmbeddedManifests.WaitForCompletion, true)
-	timeoutMs := setDefaultIntIfNil(s.DeployEmbeddedManifests.StageTimeoutMS, 1800000) // defaults to 30 minutes
+	timeoutMs := setDefaultIntIfNil(s.DeployEmbeddedManifests.StageTimeoutMS, int64(1800000)) // defaults to 30 minutes
 
 	stage := &types.ManifestStage{
 		StageMetadata:           buildStageMetadata(s, "deployManifest", index, b.isLinear),
@@ -621,7 +621,7 @@ func (b *Builder) buildRunSpinnakerPipelineStage(index int, s config.Stage) (*ty
 	failPipeline := setDefaultIfNil(s.RunSpinnakerPipeline.FailPipeline, true)
 	markUnstableAsSuccessful := setDefaultIfNil(s.RunSpinnakerPipeline.MarkUnstableAsSuccessful, false)
 	waitForCompletion := setDefaultIfNil(s.RunSpinnakerPipeline.WaitForCompletion, true)
-	timeoutMs := setDefaultIntIfNil(s.RunSpinnakerPipeline.StageTimeoutMS, 3600000) // defaults to 1 hour
+	timeoutMs := setDefaultIntIfNil(s.RunSpinnakerPipeline.StageTimeoutMS, int64(3600000)) // defaults to 1 hour
 
 	stage := &types.RunSpinnakerPipelineStage{
 		StageMetadata:                 buildStageMetadata(s, "pipeline", index, b.isLinear),

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -266,6 +266,8 @@ type RunSpinnakerPipelineStage struct {
 	FailPipeline                  *bool `json:"failPipeline,omitempty"`
 	MarkUnstableAsSuccessful      *bool `json:"markUnstableAsSuccessful,omitempty"`
 	WaitForCompletion             *bool `json:"waitForCompletion,omitempty"`
+	OverrideTimeout               bool  `json:"overrideTimeout,omitempty"`
+	StageTimeoutMS                int64 `json:"stageTimeoutMs,omitempty"`
 }
 
 func (sps RunSpinnakerPipelineStage) spinnakerStage() {}

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -121,6 +121,7 @@ type RunSpinnakerPipelineStage struct {
 	FailPipeline                  *bool `yaml:"failPipeline,omitempty"`
 	MarkUnstableAsSuccessful      *bool `yaml:"markUnstableAsSuccessful,omitempty"`
 	WaitForCompletion             *bool `yaml:"waitForCompletion,omitempty"`
+	StageTimeoutMS                int64 `yaml:"stageTimeoutMs,omitempty"`
 }
 
 // WebhookTrigger defines how a webhook can trigger a pipeline execution


### PR DESCRIPTION
After the Spinnaker upgrade, it seems that we're having issues with the default timeout values for various pipeline stages:
1. Pipelines that are kicked off by a parent Spinnaker pipeline stage, despite the parent being marked to wait for the child pipeline to complete, are being terminated by the parent stage.
1. Pipeline stages that apply embedded manifests and that do not specify an overriding timeout are being terminated before completing.

This PR sets the default timeout for kicking off child Spinnaker pipelines to 1 hour. This PR also sets the default timeout for deploying embedded manifests to 30 minutes -- this was the old behavior prior to upgrading Spinnaker.