### PR TITLE
Updates readme on how to use this app

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To use it:
 
 ```
 $ cd your-project
-$ k8s-pipeliner create pipeline.yml
+$ ~/go/bin/k8s-pipeliner create pipeline.yml
 ```
 
 If you want a pretty view and have JQ installed, you can do:


### PR DESCRIPTION
The readme is incorrect as you need to navigate into the $HOME/go/bin folder to access the k8s-pipeliner. I believe the person who wrote the readme created an alias called k8s-pipeliner.