### PR TITLE
PPP-3372 Add evaluate variables stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,26 @@ parameters:
 
 This configures your pipeline to have parameters in the UI / enable pipeline expressions.
 
+### <a name="evaluatevariables"></a> Evaluate Variables Stage
+
+The evaluate variables stage allows you to evaluate complex expressions and use them throughout your pipeline:
+
+```yaml
+- name: "evaluate variables"
+  variables:
+    - key: "my-fun-key"
+      value: ${my-complex-expression}
+```
+
+You can reference the variable by the key name:
+
+```yaml
+- name: "Some other stage"
+  someField: ${ my-fun-key }
+```
+
+### <a name="configurator"></a> Configurator
+
 Files under the `configuratorFiles` section are expected to be in the [k8s-configurator format](https://github.com/namely/k8s-configurator/blob/master/README.md#input-file-and-envs). These will be run through k8s-configurator to generate the environment-specific manifest. By default, the environment used by k8s-configurator will be determined by the account used in this stage. However, you may set the optional `env` property for configuratorFiles to override this.
 
 ```yaml

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -219,6 +219,14 @@ func (b *Builder) Pipeline() (*types.SpinnakerPipeline, error) {
 			stageIndex = stageIndex + 1
 		}
 
+		if stage.EvaluateVariables != nil {
+			s, err = b.buildEvaluateVariablesStage(stageIndex, stage)
+			if err != nil {
+				return sp, fmt.Errorf("failed to build evaluate variables stage with error: %v", err)
+			}
+			stageIndex++
+		}
+
 		if stage.RunSpinnakerPipeline != nil {
 			s, err = b.buildRunSpinnakerPipelineStage(stageIndex, stage)
 			if err != nil {
@@ -616,6 +624,20 @@ func (b *Builder) buildJenkinsStage(index int, s config.Stage) (*types.JenkinsSt
 
 	for _, p := range s.Jenkins.Parameters {
 		stage.Parameters[p.Key] = p.Value
+	}
+
+	return stage, nil
+}
+
+func (b *Builder) buildEvaluateVariablesStage(index int, s config.Stage) (*types.EvaluateVariablesStage, error) {
+	stage := &types.EvaluateVariablesStage{
+		StageMetadata: buildStageMetadata(s, "evaluate", index, b.isLinear),
+		Type:          "evaluatevariables",
+		Variables:     make(map[string]string),
+	}
+
+	for _, p := range s.EvaluateVariables.Variables {
+		stage.Variables[p.Key] = p.Value
 	}
 
 	return stage, nil

--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -631,9 +631,9 @@ func (b *Builder) buildJenkinsStage(index int, s config.Stage) (*types.JenkinsSt
 
 func (b *Builder) buildEvaluateVariablesStage(index int, s config.Stage) (*types.EvaluateVariablesStage, error) {
 	stage := &types.EvaluateVariablesStage{
-		StageMetadata: buildStageMetadata(s, "evaluate", index, b.isLinear),
-		Type:          "evaluatevariables",
-		Variables:     make(map[string]string),
+		StageMetadata:           buildStageMetadata(s, "evaluatevariables", index, b.isLinear),
+		FailOnFailedExpressions: true,
+		Variables:               make(map[string]string),
 	}
 
 	for _, p := range s.EvaluateVariables.Variables {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1197,11 +1197,10 @@ func TestBuilderPipelineStages(t *testing.T) {
 					{
 						Name: "Test EvaluateVariables Stage",
 						EvaluateVariables: &config.EvaluateVariablesStage{
-							Type: "evaluatevariables",
 							Variables: []config.PassthroughParameter{
 								{
 									Key:   "myfunkey",
-									Value: "myfunvalue",
+									Value: "${mycomplexexpression}",
 								},
 							},
 						},
@@ -1218,7 +1217,11 @@ func TestBuilderPipelineStages(t *testing.T) {
 			assert.Equal(t, "evaluatevariables", stg.Type)
 
 			variables := stg.Variables
-			assert.Equal(t, "myfunvalue", variables["myfunkey"])
+			assert.Equal(t, "${mycomplexexpression}", variables["myfunkey"])
+
+			assert.True(t, stg.FailOnFailedExpressions)
+
+			t.Logf("%+v\n", stg)
 		})
 
 		t.Run("Parses without type specified", func(t *testing.T) {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1223,35 +1223,6 @@ func TestBuilderPipelineStages(t *testing.T) {
 
 			t.Logf("%+v\n", stg)
 		})
-
-		t.Run("Parses without type specified", func(t *testing.T) {
-			pipeline := &config.Pipeline{
-				Stages: []config.Stage{
-					{
-						Name: "Test EvaluateVariables Stage",
-						EvaluateVariables: &config.EvaluateVariablesStage{
-							Variables: []config.PassthroughParameter{
-								{
-									Key:   "myfunkey",
-									Value: "myfunvalue",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			builder := builder.New(pipeline)
-			spinnaker, err := builder.Pipeline()
-			require.NoError(t, err, "error generating EvaluateVariables pipeline json")
-
-			stg := spinnaker.Stages[0].(*types.EvaluateVariablesStage)
-			assert.Equal(t, "Test EvaluateVariables Stage", stg.Name)
-			assert.Equal(t, "evaluatevariables", stg.Type)
-
-			variables := stg.Variables
-			assert.Equal(t, "myfunvalue", variables["myfunkey"])
-		})
 	})
 
 	t.Run("RunSpinnakerPipeline stage is parsed correctly", func(t *testing.T) {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1220,6 +1220,35 @@ func TestBuilderPipelineStages(t *testing.T) {
 			variables := stg.Variables
 			assert.Equal(t, "myfunvalue", variables["myfunkey"])
 		})
+
+		t.Run("Parses without type specified", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Name: "Test EvaluateVariables Stage",
+						EvaluateVariables: &config.EvaluateVariablesStage{
+							Variables: []config.PassthroughParameter{
+								{
+									Key:   "myfunkey",
+									Value: "myfunvalue",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating EvaluateVariables pipeline json")
+
+			stg := spinnaker.Stages[0].(*types.EvaluateVariablesStage)
+			assert.Equal(t, "Test EvaluateVariables Stage", stg.Name)
+			assert.Equal(t, "evaluatevariables", stg.Type)
+
+			variables := stg.Variables
+			assert.Equal(t, "myfunvalue", variables["myfunkey"])
+		})
 	})
 
 	t.Run("RunSpinnakerPipeline stage is parsed correctly", func(t *testing.T) {

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -556,3 +556,15 @@ type OptionalStageSupport struct {
 	Expression string `json:"expression"`
 	Type       string `json:"type"`
 }
+
+// EvaluateVariablesStage parses complex expressions for reuse throughout a pipeline
+type EvaluateVariablesStage struct {
+	StageMetadata
+
+	Type      string            `json:"type,omitempty"`
+	Variables map[string]string `json:"variables,omitempty"`
+}
+
+func (evs EvaluateVariablesStage) spinnakerStage() {}
+
+var _ Stage = EvaluateVariablesStage{}

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -561,7 +561,8 @@ type OptionalStageSupport struct {
 type EvaluateVariablesStage struct {
 	StageMetadata
 
-	Type      string            `json:"type,omitempty"`
+	FailOnFailedExpressions bool `json:"failOnFailedExpessions"`
+
 	Variables map[string]string `json:"variables,omitempty"`
 }
 

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -160,7 +160,7 @@ type Stage struct {
 	WebHook                 *WebHookStage              `yaml:"webHook,omitempty"`
 	Jenkins                 *JenkinsStage              `yaml:"jenkins,omitempty"`
 	RunSpinnakerPipeline    *RunSpinnakerPipelineStage `yaml:"spinnaker,omitempty"`
-	EvaluateVariables       *EvaluateVariablesStage    `yaml:"evaluatevariables,omitempty"`
+	EvaluateVariables       *EvaluateVariablesStage    `yaml:"variables,omitempty"`
 }
 
 // Notification config from pipeline configuration on a stage or pipeline

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -160,6 +160,7 @@ type Stage struct {
 	WebHook                 *WebHookStage              `yaml:"webHook,omitempty"`
 	Jenkins                 *JenkinsStage              `yaml:"jenkins,omitempty"`
 	RunSpinnakerPipeline    *RunSpinnakerPipelineStage `yaml:"spinnaker,omitempty"`
+	EvaluateVariables       *EvaluateVariablesStage    `yaml:"evaluatevariables,omitempty"`
 }
 
 // Notification config from pipeline configuration on a stage or pipeline
@@ -365,4 +366,10 @@ func findImageDescription(containerName string, refs []ImageDescriptionRef) *Ima
 	}
 
 	return nil
+}
+
+// EvaluateVariablesStage parses complex expressions for reuse throughout a pipeline
+type EvaluateVariablesStage struct {
+	Type      string                 `yaml:"type,omitempty"`
+	Variables []PassthroughParameter `yaml:"variables,omitempty"`
 }

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -370,6 +370,5 @@ func findImageDescription(containerName string, refs []ImageDescriptionRef) *Ima
 
 // EvaluateVariablesStage parses complex expressions for reuse throughout a pipeline
 type EvaluateVariablesStage struct {
-	Type      string                 `yaml:"type,omitempty"`
 	Variables []PassthroughParameter `yaml:"variables,omitempty"`
 }


### PR DESCRIPTION
Add parsing for an evaluate variables stage in spinnaker

https://spinnaker.io/docs/guides/user/pipeline/expressions/#create-variables-using-an-evaluate-variables-stage

Allows evaluation of complex expressions that are stored in variables that can be reused throughout a pipeline. Can be referenced by the variable name plainly, e.g. 

```yaml
- name: EvaluateVariables
  variables:
  - key: ta
    value: da

...

- name: some other stage
  somefield: ${ ta }
```