### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Kubernetes Pipeliner
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/03d22314658645d181c489328b1f3309)](https://app.codacy.com/gh/namely/k8s-pipeliner/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/03d22314658645d181c489328b1f3309)](https://app.codacy.com/gh/namely/k8s-pipeliner/dashboard)
 
 [![Build Status](https://travis-ci.com/namely/k8s-pipeliner.svg?branch=master)](https://travis-ci.com/namely/k8s-pipeliner)
 [![Coverage Status](https://coveralls.io/repos/github/namely/k8s-pipeliner/badge.svg)](https://coveralls.io/github/namely/k8s-pipeliner)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/03d22314658645d181c489328b1f3309)](https://app.codacy.com/gh/namely/k8s-pipeliner/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/03d22314658645d181c489328b1f3309)](https://app.codacy.com/gh/namely/k8s-pipeliner/dashboard)
-
 [![Build Status](https://travis-ci.com/namely/k8s-pipeliner.svg?branch=master)](https://travis-ci.com/namely/k8s-pipeliner)
 [![Coverage Status](https://coveralls.io/repos/github/namely/k8s-pipeliner/badge.svg)](https://coveralls.io/github/namely/k8s-pipeliner)
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.