### PR TITLE
Deprecation of 'go get' for installing executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ stages:
 If you have a Go environment installed and configured, you can use `go get` to install the latest package of this project:
 
 ```
-$ go get -u github.com/namely/k8s-pipeliner/cmd/k8s-pipeliner
+$ go install github.com/namely/k8s-pipeliner/cmd/k8s-pipeliner
 ```
 
 To use it:


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. Specifically, go get will always act as if the -d flag were enabled.
https://go.dev/doc/go-get-install-deprecation