### PR TITLE
workaround(validate): panic when trying to use inexistent .Error()

### DIFF
--- a/cmd/k8s-pipeliner/main.go
+++ b/cmd/k8s-pipeliner/main.go
@@ -53,8 +53,8 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		fmt.Printf("error: %v", err)
+		os.Exit(255)
 	}
 }
 


### PR DESCRIPTION
workaround for https://github.com/namely/k8s-pipeliner/issues/77

This doesn't fix the problem. Even when `validate` is successful, it enters into the `err != nil`... changing the exit code to `255`.