### PR TITLE
SRE-8924: add TrafficManagement to stage metadata

### DIFF
--- a/pipeline/builder/builder.go
+++ b/pipeline/builder/builder.go
@@ -838,6 +838,13 @@ func buildStageMetadata(s config.Stage, t string, index int, linear bool) types.
 		Type:                 t,
 		Notifications:        notifications,
 		SendNotifications:    (len(notifications) > 0),
+		TrafficManagement: &types.TrafficManagement{
+			Enabled: false,
+			Options: &types.TrafficManagementOptions{
+				EnableTraffic: false,
+				Services:      []string{},
+			},
+		},
 	}
 
 	if len(s.Condition) > 0 {

--- a/pipeline/builder/builder_test.go
+++ b/pipeline/builder/builder_test.go
@@ -1399,6 +1399,22 @@ func TestBuilderPipelineStages(t *testing.T) {
 
 			assert.Equal(t, []string{"2"}, spinnaker.Stages[0].(*types.RunSpinnakerPipelineStage).StageMetadata.RequisiteStageRefIds)
 		})
+
+		t.Run("TrafficManagement is assigned", func(t *testing.T) {
+			pipeline := &config.Pipeline{
+				Stages: []config.Stage{
+					{
+						Deploy:   &config.DeployStage{},
+					},
+				},
+			}
+
+			builder := builder.New(pipeline)
+			spinnaker, err := builder.Pipeline()
+			require.NoError(t, err, "error generating pipeline json")
+
+			assert.Equal(t, &types.TrafficManagement{Enabled: false, Options: &types.TrafficManagementOptions{EnableTraffic: false, Services: []string{}}}, spinnaker.Stages[0].(*types.DeployStage).StageMetadata.TrafficManagement)
+		})
 	})
 }
 

--- a/pipeline/builder/types/triggers.go
+++ b/pipeline/builder/types/triggers.go
@@ -20,6 +20,7 @@ type StageMetadata struct {
 	Notifications        []Notification        `json:"notifications,omitempty"`
 	SendNotifications    bool                  `json:"sendNotifications,omitempty"`
 	StageEnabled         *OptionalStageSupport `json:"stageEnabled,omitempty"`
+	TrafficManagement    *TrafficManagement    `json:"trafficManagement"`
 }
 
 // JenkinsTrigger constructs the JSON necessary to include a Jenkins trigger

--- a/pipeline/builder/types/types.go
+++ b/pipeline/builder/types/types.go
@@ -569,3 +569,15 @@ type EvaluateVariablesStage struct {
 func (evs EvaluateVariablesStage) spinnakerStage() {}
 
 var _ Stage = EvaluateVariablesStage{}
+
+// TrafficManagement is a struct for the Spinnaker traffic management configuration
+type TrafficManagement struct {
+	Enabled bool                      `json:"enabled" default:"false"`
+	Options *TrafficManagementOptions `json:"options"`
+}
+
+// TrafficManagementOptions options for traffic management
+type TrafficManagementOptions struct {
+	EnableTraffic bool     `json:"enableTraffic" default:"false"`
+	Services      []string `json:"services" default:"[]"`
+}


### PR DESCRIPTION
Spinnaker >= 1.30 validates the field `.trafficManagement` from `.stages[]`; If this field is missing, Spinnaker can not save the new pipeline (json file) and responds with `error: null`.

This PR adds the minimum structure of `.trafficManagement` to the built object.