### PR TITLE
[SRE-8926] K8s-pipeliner golang upgraded to 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 .PHONY: deps
 deps:
 	GO111MODULE=on go mod vendor
-	go install github.com/mattn/goveralls@0.12
+	go install github.com/mattn/goveralls@v0.0.12
 	go install github.com/go-playground/overalls@latest
 
 .PHONY: coveralls

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ test:
 .PHONY: deps
 deps:
 	GO111MODULE=on go mod vendor
-	go install github.com/mattn/goveralls
-	go install github.com/go-playground/overalls
+	go install github.com/mattn/goveralls@0.12
+	go install github.com/go-playground/overalls@latest
 
 .PHONY: coveralls
 coveralls:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/namely/k8s-pipeliner
 
-go 1.13
+go 1.22
 
 require (
 	github.com/hashicorp/go-multierror v1.0.0
@@ -8,9 +8,28 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.4
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.5
 	k8s.io/client-go v11.0.0+incompatible
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680 // indirect
+	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )


### PR DESCRIPTION
This PR is upgrading the Golang version to 1.22

https://namely.atlassian.net/browse/SRE-8926